### PR TITLE
fix: アセットが読み込まれない

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -18,7 +18,7 @@ jobs:
           node-version: '16'
           cache: 'yarn'
       - run: yarn install --check-files --frozen-lockfile --non-interactive
-      - run: yarn --cwd docs build
+      - run: yarn --cwd docs build --base /vue-3-practices
       - uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.ref == 'refs/heads/main' }}
         with:


### PR DESCRIPTION
base pathが期待したものでないことが原因

参考: https://zenn.dev/shu1007/articles/c65dee06b29772#%E3%83%99%E3%83%BC%E3%82%B9%E3%83%91%E3%82%B9%E3%81%AE%E8%A8%AD%E5%AE%9A