### PR TITLE
chore: ハンズオンのテンプレートの並びを上に

### DIFF
--- a/handson-vue/src/App.vue
+++ b/handson-vue/src/App.vue
@@ -1,3 +1,6 @@
+<template>
+</template>
+
 <script>
 export default {
   setup() {
@@ -5,9 +8,6 @@ export default {
   }
 }
 </script>
-
-<template>
-</template>
 
 <style>
 </style>


### PR DESCRIPTION
スライドのコードもテンプレートが上なので、初学者としては並びが同じなほうが混乱しないため