### PR TITLE
fix: ヘッダーの配置に意図しない余白が生じる

### DIFF
--- a/handson-gallery-shoes-cart-finish/src/App.vue
+++ b/handson-gallery-shoes-cart-finish/src/App.vue
@@ -51,6 +51,8 @@ export default {
   padding: 0 1rem;
   z-index: 2;
   box-sizing: border-box;
+  top: 0;
+  left: 0;
 }
 .shopping-header h1 {
   font-size: 1.4rem;


### PR DESCRIPTION
位置を明示的に指定することによって対応

resolve #180 