### PR TITLE
chore: アバター画像の外部URLを取り除く

### DIFF
--- a/handson-nuxt-playground/server/api/users.js
+++ b/handson-nuxt-playground/server/api/users.js
@@ -5,32 +5,24 @@ export default () => {
       email: "kitada_yuu@example.com",
       pref: "東京都",
       city: "府中市",
-      image:
-        "https://raw.githubusercontent.com/tuqulore/vue-3-practices/main/handson-nuxt-playground/public/user-photo-1.png",
     },
     {
       name: "小幡 有起哉",
       email: "obata_yukiya@example.com",
       pref: "大分県",
       city: "豊後高田市",
-      image:
-        "https://raw.githubusercontent.com/tuqulore/vue-3-practices/main/handson-nuxt-playground/public/user-photo-2.png",
     },
     {
       name: "伊藤 まひる",
       email: "itou_mahiru@example.com",
       pref: "熊本県",
       city: "葦北郡芦北町",
-      image:
-        "https://raw.githubusercontent.com/tuqulore/vue-3-practices/main/handson-nuxt-playground/public/user-photo-3.png",
     },
     {
       name: "有賀 雅功",
       email: "ariga_masatoshi@example.com",
       pref: "徳島県",
       city: "鳴門市",
-      image:
-        "https://raw.githubusercontent.com/tuqulore/vue-3-practices/main/handson-nuxt-playground/public/user-photo-4.png",
     },
   ];
 };


### PR DESCRIPTION
現状外部URLから画像を参照せずとも表示可能であるため

resolve #102 