### PR TITLE
fix: Composite Actions のファイルの参照に失敗する

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -15,7 +15,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ./setup
+      - uses: .github/workflows/setup
       - run: yarn --cwd docs build --base /vue-3-practices
       - uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
ref #303

おそらく `jobs.<job_id>.stemps[*].working-directory` 未指定の場合 プロジェクトルートからの相対パスが必要であることが原因