### PR TITLE
chore(handson-sticky): @nuxt/eslint-config 導入 & Auto Imports 対応

### DIFF
--- a/handson-fetch-router-nuxt-finish/.eslintrc.cjs
+++ b/handson-fetch-router-nuxt-finish/.eslintrc.cjs
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ["@nuxt/eslint-config", "prettier"],
+  rules: {
+    "no-undef": "warn",
+  },
 };

--- a/handson-nuxt-playground/.eslintrc.cjs
+++ b/handson-nuxt-playground/.eslintrc.cjs
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ["@nuxt/eslint-config", "prettier"],
+  rules: {
+    "no-undef": "warn",
+  },
 };

--- a/handson-nuxt/.eslintrc.cjs
+++ b/handson-nuxt/.eslintrc.cjs
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ["@nuxt/eslint-config", "prettier"],
+  rules: {
+    "no-undef": "warn",
+  },
 };

--- a/handson-sticky/.eslintrc.cjs
+++ b/handson-sticky/.eslintrc.cjs
@@ -1,3 +1,6 @@
 module.exports = {
-  extends: ["plugin:vue/vue3-recommended", "prettier"],
+  extends: ["@nuxt/eslint-config", "prettier"],
+  rules: {
+    "no-undef": "warn",
+  },
 };

--- a/handson-sticky/components/StickyNote.vue
+++ b/handson-sticky/components/StickyNote.vue
@@ -8,6 +8,7 @@ const stickies = useStickies();
 const props = defineProps({
   data: {
     type: Object,
+    required: true,
   },
 });
 
@@ -46,9 +47,9 @@ watch([textContent, bgColor], () => update());
 </script>
 
 <template>
-  <div class="sticky" ref="el" :style="cssStyle">
+  <div ref="el" class="sticky" :style="cssStyle">
     <textarea v-model="textContent" class="textarea"></textarea>
-    <input type="color" v-model="bgColor" />
+    <input v-model="bgColor" type="color" />
   </div>
 </template>
 

--- a/handson-sticky/nuxt.config.js
+++ b/handson-sticky/nuxt.config.js
@@ -1,2 +1,4 @@
 // https://nuxt.com/docs/getting-started/configuration
+import { defineNuxtConfig } from "nuxt/config";
+
 export default defineNuxtConfig({});

--- a/handson-sticky/package.json
+++ b/handson-sticky/package.json
@@ -7,10 +7,10 @@
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
   "devDependencies": {
+    "@nuxt/eslint-config": "^0.2.0",
     "@vueuse/core": "^10.7.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-vue": "^9.19.2",
     "nuxt": "3.8.2",
     "prettier": "^3.1.1"
   },

--- a/handson-sticky/pages/index.vue
+++ b/handson-sticky/pages/index.vue
@@ -11,8 +11,12 @@ const addSticky = () => {
 <template>
   <div>
     <h1>Top page</h1>
-    <p v-for="sticky in stickies.data">{{ sticky }}</p>
-    <Sticky v-for="sticky in stickies.data" :data="sticky" />
+    <p v-for="(sticky, index) in stickies.data" :key="index">{{ sticky }}</p>
+    <StickyNote
+      v-for="(sticky, index) in stickies.data"
+      :key="index"
+      :data="sticky"
+    />
     <button @click="addSticky">付箋を追加する</button>
     <NuxtLink to="/sub">sub</NuxtLink>
   </div>

--- a/handson-sticky/pages/sub.vue
+++ b/handson-sticky/pages/sub.vue
@@ -12,7 +12,11 @@ const addSticky = () => {
   <div>
     <h1>Sub page</h1>
     <p>ここはサブページです</p>
-    <Sticky v-for="sticky in stickies.data" :data="sticky" />
+    <StickyNote
+      v-for="(sticky, index) in stickies.data"
+      :key="index"
+      :data="sticky"
+    />
     <button @click="addSticky">付箋を追加する</button>
     <NuxtLink to="/">home</NuxtLink>
   </div>


### PR DESCRIPTION
- Auto Imports で使用可能な機能がESLintでエラーにならないように警告に留めます
- その他付箋アプリで引っかかったルールに対処しています（とくにコンポーネント名がSticky→StickyNoteになった点は注意してください）