### PR TITLE
docs: composables ディレクトリのコードサンプルの見直し

### DIFF
--- a/docs/slides.md
+++ b/docs/slides.md
@@ -1822,8 +1822,6 @@ const { data: users } = await useFetch("/api/users");
 アプリで再利用したいロジックを管理することができる。js ファイルではあるが、Vue コンポーネントで使ってきた関数を使用していることがわかる。
 
 ```js
-import { ref, readonly } from "#app";
-
 export default () => {
   const count = ref(0);
   const increment = () => count.value++;


### PR DESCRIPTION
```
import { ref, readonly } from "#app";
```
そもそもなぜこのコードが記載されていたのか不明。
こちらローカルで動作確認済み。