### PR TITLE
HTML の記述に関する警告がスライドのビルド時表示される

### DIFF
--- a/docs/slides.md
+++ b/docs/slides.md
@@ -2333,7 +2333,7 @@ Nuxt 3 を使ってウェブアプリケーションをつくっていく準備�
 
 <img src="/fig-vueuse.png" alt="VueUse" class="h-8/12" />
 
-<a target="_blank" rel="noopener noreferrer" href="https://vueuse.org/">https://vueuse.org/</a>
+https://vueuse.org/
 
 <p>
 今回は <a target="_blank" rel="noopener noreferrer" href="https://vueuse.org/core/usedraggable/#usedraggable">useDraggable</a> を使います


### PR DESCRIPTION
a 要素の入れ子は HTML 仕様違反になるので、避けます

```
1:21:08 [vite] warning: <a> cannot be child of <a>, according to HTML specifications. This can cause hydration errors or potentially disrupt future functionality.
5  |  <p>様々な Vue で使える便利なユーティリティがあります。</p>
6  |  <img src="/fig-vueuse.png" alt="VueUse" class="h-8/12" />
7  |  <p><a target="_blank" rel="noopener noreferrer" href="https://vueuse.org/"><a href="https://vueuse.org/" target="_blank">https://vueuse.org/</a></a></p>
   |                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
8  |  <p>
9  |  今回は <a target="_blank" rel="noopener noreferrer" href="https://vueuse.org/core/usedraggable/#usedraggable">useDraggable</a> を使います
```