### PR TITLE
type module 指定して CommonJS を使わないことにする

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,6 +2,7 @@
   "name": "vue-3-practices-docs",
   "description": "Vue 3 / Nuxt 3の演習資料",
   "version": "1.0.0",
+  "type": "module",
   "dependencies": {
     "@slidev/cli": "0.49.29",
     "@slidev/theme-default": "0.25.0",

--- a/handson-fetch-router-finish/package.json
+++ b/handson-fetch-router-finish/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/handson-fetch-router-nuxt-finish/package.json
+++ b/handson-fetch-router-nuxt-finish/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "devDependencies": {
     "@nuxt/eslint": "0.7.3",
     "@nuxt/eslint-config": "^0.7.0",

--- a/handson-fetch-router/package.json
+++ b/handson-fetch-router/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/handson-gallery-shoes-cart-finish/package.json
+++ b/handson-gallery-shoes-cart-finish/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/handson-gallery-shoes-finish/package.json
+++ b/handson-gallery-shoes-finish/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/handson-gallery-shoes/package.json
+++ b/handson-gallery-shoes/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/handson-grid-component-finish/package.json
+++ b/handson-grid-component-finish/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/handson-grid-component/package.json
+++ b/handson-grid-component/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/handson-nuxt-playground/package.json
+++ b/handson-nuxt-playground/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "devDependencies": {
     "@nuxt/eslint": "0.7.3",
     "@nuxt/eslint-config": "^0.7.0",

--- a/handson-nuxt/package.json
+++ b/handson-nuxt/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "devDependencies": {
     "@nuxt/eslint": "0.7.3",
     "@nuxt/eslint-config": "^0.7.0",

--- a/handson-password-checker-finish/package.json
+++ b/handson-password-checker-finish/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/handson-password-checker/package.json
+++ b/handson-password-checker/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/handson-sticky/package.json
+++ b/handson-sticky/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "devDependencies": {
     "@nuxt/eslint": "0.7.3",
     "@nuxt/eslint-config": "^0.7.0",

--- a/handson-vue-playground/package.json
+++ b/handson-vue-playground/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33",
     "vue-router": "4"

--- a/handson-vue/package.json
+++ b/handson-vue/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "handson*",
     "practice*"
   ],
+  "type": "module",
   "devDependencies": {
     "@lerna-lite/cli": "^3.10.1",
     "@lerna-lite/run": "^3.10.1",

--- a/practice-computed-answer/package.json
+++ b/practice-computed-answer/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-computed/package.json
+++ b/practice-computed/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-debounce-answer/package.json
+++ b/practice-debounce-answer/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-debounce/package.json
+++ b/practice-debounce/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-emit-event-handling-answer/package.json
+++ b/practice-emit-event-handling-answer/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-emit-event-handling/package.json
+++ b/practice-emit-event-handling/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-fetch-answer/package.json
+++ b/practice-fetch-answer/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-fetch/package.json
+++ b/practice-fetch/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-mounted-answer/package.json
+++ b/practice-mounted-answer/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-mounted/package.json
+++ b/practice-mounted/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-mustache-setup-answer/package.json
+++ b/practice-mustache-setup-answer/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-mustache-setup/package.json
+++ b/practice-mustache-setup/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-reactive-class-binding-event-handling-answer/package.json
+++ b/practice-reactive-class-binding-event-handling-answer/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-reactive-class-binding-event-handling/package.json
+++ b/practice-reactive-class-binding-event-handling/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-reactive-props-component-v-model-answer-1/package.json
+++ b/practice-reactive-props-component-v-model-answer-1/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-reactive-props-component-v-model-answer-2/package.json
+++ b/practice-reactive-props-component-v-model-answer-2/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-reactive-props-component-v-model-answer-3/package.json
+++ b/practice-reactive-props-component-v-model-answer-3/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-reactive-props-component-v-model/package.json
+++ b/practice-reactive-props-component-v-model/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-scoped-css-component-answer/package.json
+++ b/practice-scoped-css-component-answer/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-scoped-css-component/package.json
+++ b/practice-scoped-css-component/package.json
@@ -6,6 +6,7 @@
   "bugs": {
     "url": "https://github.com/tuqulore/vue-3-practices/issues"
   },
+  "type": "module",
   "dependencies": {
     "vue": "^3.2.33"
   },

--- a/practice-slot-answer/package.json
+++ b/practice-slot-answer/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-slot/package.json
+++ b/practice-slot/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-style-answer/package.json
+++ b/practice-style-answer/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-style/package.json
+++ b/practice-style/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-v-for-answer/package.json
+++ b/practice-v-for-answer/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-v-for/package.json
+++ b/practice-v-for/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-v-if-answer/package.json
+++ b/practice-v-if-answer/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-v-if/package.json
+++ b/practice-v-if/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-v-model-answer/package.json
+++ b/practice-v-model-answer/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-v-model/package.json
+++ b/practice-v-model/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-vue-router-answer-1/package.json
+++ b/practice-vue-router-answer-1/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-vue-router-answer-2/package.json
+++ b/practice-vue-router-answer-2/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",

--- a/practice-vue-router/package.json
+++ b/practice-vue-router/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "vue": "^3.2.33"
   },
+  "type": "module",
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.1",
     "eslint": "^9.0.0",


### PR DESCRIPTION
これにより https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated が解消されます

resolve #347