### PR TITLE
`sticky.id` を key プロパティにあらかじめ使用する

### DIFF
--- a/handson-sticky/pages/index.vue
+++ b/handson-sticky/pages/index.vue
@@ -11,10 +11,10 @@ const addSticky = () => {
 <template>
   <div>
     <h1>Top page</h1>
-    <p v-for="(sticky, index) in stickies.data" :key="index">{{ sticky }}</p>
+    <p v-for="sticky in stickies.data" :key="sticky.id">{{ sticky }}</p>
     <StickyNote
-      v-for="(sticky, index) in stickies.data"
-      :key="index"
+      v-for="sticky in stickies.data"
+      :key="sticky.id"
       :data="sticky"
     />
     <button @click="addSticky">付箋を追加する</button>

--- a/handson-sticky/pages/sub.vue
+++ b/handson-sticky/pages/sub.vue
@@ -13,8 +13,8 @@ const addSticky = () => {
     <h1>Sub page</h1>
     <p>ここはサブページです</p>
     <StickyNote
-      v-for="(sticky, index) in stickies.data"
-      :key="index"
+      v-for="sticky in stickies.data"
+      :key="sticky.id"
       :data="sticky"
     />
     <button @click="addSticky">付箋を追加する</button>


### PR DESCRIPTION
resove #714

初学者が自己解決するには難しい落とし穴なので、あらかじめ解決しておく